### PR TITLE
esp32s2: fix JUMPS offset interpretation (make same as JUMPR) (GCC-337)

### DIFF
--- a/gas/config/tc-esp32s2ulp.c
+++ b/gas/config/tc-esp32s2ulp.c
@@ -1224,7 +1224,7 @@ INSTR_T esp32s2ulp_cmd_jump_rels(Expr_Node* step, Expr_Node* thresh, int cond)
 	int thresh_val = EXPR_VALUE(thresh);
 
 	{
-		unsigned int local_op = I_JUMP_RELS(thresh_val, cond, step_val);
+		unsigned int local_op = I_JUMP_RELS(thresh_val, cond, step_val>>2);
 
 		INSTR_T result = conscode(gencode(local_op),
 			conctcode(Expr_Node_Gen_Reloc(step, BFD_RELOC_ESP32S2ULP_JUMPR_STEP),

--- a/gas/config/tc-esp32ulp_esp32s2.c
+++ b/gas/config/tc-esp32ulp_esp32s2.c
@@ -279,7 +279,7 @@ INSTR_T esp32ulp_cmd_jump_rels_esp32s2(Expr_Node* step, Expr_Node* thresh, int c
 	int step_val = EXPR_VALUE(step);
 	int thresh_val = EXPR_VALUE(thresh);
 	{
-		unsigned int local_op = I_JUMP_RELS(thresh_val, cond, step_val);
+		unsigned int local_op = I_JUMP_RELS(thresh_val, cond, step_val>>2);
 
 		INSTR_T result = conscode(gencode(local_op),
 			conctcode(Expr_Node_Gen_Reloc(step, BFD_RELOC_ESP32S2ULP_JUMPR_STEP),

--- a/gas/testsuite/gas/esp32ulp/esp32s2/compare/esp32s2ulp_jump.lst
+++ b/gas/testsuite/gas/esp32ulp/esp32s2/compare/esp32s2ulp_jump.lst
@@ -87,8 +87,8 @@ ESP32ULP GAS  ./gas/testsuite/gas/esp32ulp/esp32s2/esp32s2ulp_jump.s 			page 1
   69      0000DE82 
   70              	
   71              	// Jumps commands...
-  72 00f0 04001288 	    jumps 0x4, 0x04, EQ
-  73 00f4 04001288 	    jumps 0x04, check_thres1, EQ
+  72 00f0 04000688 	    jumps 0x4, 0x04, EQ
+  73 00f4 04000688 	    jumps 0x04, check_thres1, EQ
   74 00f8 0400EA8A 	    jumps check_jump1, check_thres1, EQ
   75 00fc 0000EE8A 	    jumps check_jump1, check_thres2, EQ
   76 0100 0400F28A 	    jumps check_jump2, check_thres1, EQ
@@ -111,8 +111,8 @@ ESP32ULP GAS  ./gas/testsuite/gas/esp32ulp/esp32s2/esp32s2ulp_jump.s 			page 1
   91      00000A82 
   92              	
   93              	    //jumps with negative offset
-  94 0138 0000128A 	    jumps -0x4, 0x00, EQ
-  95 013c 0080108A 	    jumps -0x4, 0x00, LT
-  96 0140 0080118A 	    jumps -0x4, 0x00, GT
-  97 0144 0080128A 	    jumps -0x4, 0x00, LE
-  98 0148 0080138A 	    jumps -0x4, 0x00, GE
+  94 0138 0000068A 	    jumps -0x4, 0x00, EQ
+  95 013c 0080048A 	    jumps -0x4, 0x00, LT
+  96 0140 0080058A 	    jumps -0x4, 0x00, GT
+  97 0144 0080068A 	    jumps -0x4, 0x00, LE
+  98 0148 0080078A 	    jumps -0x4, 0x00, GE


### PR DESCRIPTION
This PR fixes the behaviour of the esp32s2 assembler, in how it treats an offset given to JUMPS. This fix aligns the behaviour with that of JUMP and JUMPR and also with how JUMPS works in the ESP32 (not S2) assembler.

## Incorrect behaviour
As per [ESP32-S2 ULP coprocessor instruction set documentation](https://docs.espressif.com/projects/esp-idf/en/v5.0.2/esp32/api-reference/system/ulp_instruction_set.html#note-about-addressing), all JUMP family processor instructions use an offset in 32-bit words (even though in assembly source offsets are specified as bytes).

For immediate values, JUMP and JUMPR work as per documentation. In other words an offset given in the assembly source in bytes is correctly converted to 32-bit words (by doing `>>2`) when creating the binary instruction.

With JUMPS however any value given in the assembly source file is kept as-is when creating the binary instruction. Thus for example 4 bytes specified in the source will stay 4 (words) in the binary instruction, instead of 1 (word), effectively causing a 4x larger offset than intended.

## Expected behaviour
Immediate offsets given to the JUMPS instruction in assembly source should be treated as bytes, with the assembler converting that value to number of 32-bit words when creating the processor instruction. 4 bytes should thus become 1 word in the processor instruction.

This behaviour would match how offsets to the JUMP and JUMPR instruction are treated, and also matches how the ESP32 (not s2) assembler treats offsets for the JUMPS instruction.

## How it was tested
This change was tested on an actual ESP32-S2 with the following code:

```gas
.data
val: .long 0

.text
entry:
  move r3, val

  jumps 4, 42, lt

right:
  move r0, 66  # correct jump
  jump end
  nop
wrong:
  move r0, 73  # incorrect jump
  nop
end:
  st r0, r3, 0
  halt
```

Before the fix, the JUMPS instruction jumped 4 instructions forward, and "val" was set to 73. After the fix JUMPS correctly jumped 1 instruction forward (4 bytes = 1 word), and "val" was set to 66.