### PR TITLE
Fix sub_opcode for STO instruction (GCC-336)

### DIFF
--- a/gas/config/tc-esp32s2ulp.c
+++ b/gas/config/tc-esp32s2ulp.c
@@ -1383,7 +1383,7 @@ INSTR_T esp32s2ulp_wr_mem_sti(int dst_reg, int src_reg)
 INSTR_T esp32s2ulp_wr_mem_offset(Expr_Node* offset)
 {
     int addr_val = EXPR_VALUE(offset);
-    unsigned int local_op = WR_MEM(0, 0, addr_val >> 2, 0, 0, 0, 0x2);
+    unsigned int local_op = WR_MEM(0, 0, addr_val >> 2, 0, 0, 0, 0x3);
 
     return conscode(gencode(local_op), Expr_Node_Gen_Reloc(offset, BFD_RELOC_ESP32S2ULP_WR_MEM));
 }

--- a/gas/config/tc-esp32ulp_esp32s2.c
+++ b/gas/config/tc-esp32ulp_esp32s2.c
@@ -375,7 +375,7 @@ INSTR_T esp32ulp_wr_mem_sti_esp32s2(int dst_reg, int src_reg)
 INSTR_T esp32ulp_wr_mem_sto_esp32s2(Expr_Node* offset)
 {
     int addr_val = EXPR_VALUE(offset);
-    unsigned int local_op = WR_MEM(0, 0, addr_val >> 2, 0, 0, 0, 0x2);
+    unsigned int local_op = WR_MEM(0, 0, addr_val >> 2, 0, 0, 0, 0x3);
 
     return conscode(gencode(local_op), Expr_Node_Gen_Reloc(offset, BFD_RELOC_ESP32S2ULP_WR_MEM));
 }


### PR DESCRIPTION
This PR fixes the `sub_opcode` of the `STO` instruction for the ESP32-S2 and S3 ULP-FSM.

As per ESP32-S2/S3 Technical Reference Manual, the `sub_opcode` for Automatic Storage Mode ST-OFFSET should be `3`, not `2`.

See:
* page 35, figure 1-11, of the ESP32-S2 TRM v1.1 (2022-09-23)
* as well as page 305, figure 2-11, of the ESP32-S3 TRM v1.3 (2023-07-04)

Refer also to the "macro implementation" in the ESP-IDF:
* sub_opcode `SUB_OPCODE_ST_OFFSET` is defined to be `3` [here](https://github.com/espressif/esp-idf/blob/d2471b11e78fb0af612dfa045255ac7fe497bea8/components/ulp/ulp_fsm/include/esp32s2/ulp.h#L57)
* and then used in the `STO` instruction [here](https://github.com/espressif/esp-idf/blob/d2471b11e78fb0af612dfa045255ac7fe497bea8/components/ulp/ulp_fsm/include/esp32s2/ulp.h#L567)
