### PR TITLE
Fix ESP32-S2 peripheral register address range (GCC-335)

### DIFF
--- a/gas/config/tc-esp32s2ulp.c
+++ b/gas/config/tc-esp32s2ulp.c
@@ -1249,7 +1249,7 @@ INSTR_T esp32s2ulp_cmd_reg_rd(Expr_Node* addr, Expr_Node* high, Expr_Node* low)
 		{
 			addr_val = (addr_val - DR_REG_RTCCNTL_BASE)/4;
 		} else {
-			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3ff48000 .. 0x3ff49000.");
+			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3f408000 .. 0x3f409000.");
 		}
 	}
 	unsigned int local_op = I_RD_REG(addr_val, low_val, high_val);
@@ -1273,7 +1273,7 @@ INSTR_T esp32s2ulp_cmd_reg_wr(Expr_Node* addr, Expr_Node* high, Expr_Node* low, 
 		{
 			addr_val = (addr_val - DR_REG_RTCCNTL_BASE)/4;
 		} else {
-			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3ff48000 .. 0x3ff49000.");
+			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3f408000 .. 0x3f409000.");
 		}
 	}
 	unsigned int local_op = I_WR_REG(addr_val, low_val, high_val, data_val);

--- a/gas/config/tc-esp32ulp_esp32s2.c
+++ b/gas/config/tc-esp32ulp_esp32s2.c
@@ -77,7 +77,7 @@ INSTR_T esp32ulp_cmd_reg_rd_esp32s2(Expr_Node* addr, Expr_Node* high, Expr_Node*
 		{
 			addr_val = (addr_val - DR_REG_RTCCNTL_BASE)/4;
 		} else {
-			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3ff48000 .. 0x3ff49000.");
+			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3f408000 .. 0x3f409000.");
 		}
 	}
 	unsigned int local_op = I_RD_REG(addr_val, low_val, high_val);
@@ -101,7 +101,7 @@ INSTR_T esp32ulp_cmd_reg_wr_esp32s2(Expr_Node* addr, Expr_Node* high, Expr_Node*
 		{
 			addr_val = (addr_val - DR_REG_RTCCNTL_BASE)/4;
 		} else {
-			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3ff48000 .. 0x3ff49000.");
+			error("%s","Register address out of range. Must be 0..0x3ff, or in range of 0x3f408000 .. 0x3f409000.");
 		}
 	}
 	unsigned int local_op = I_WR_REG(addr_val, low_val, high_val, data_val);

--- a/include/elf/esp32s2ulp.h
+++ b/include/elf/esp32s2ulp.h
@@ -80,7 +80,7 @@ START_RELOC_NUMBERS (elf_esp32s2ulp_reloc_type)
 #define	EF_ESP32S2ULP_PIC_FLAGS	(EF_ESP32S2ULP_PIC | EF_ESP32S2ULP_FDPIC)
 
 #define DR_REG_MAX_DIRECT                       0x3ff
-#define DR_REG_RTCCNTL_BASE                     0x3ff48000
-#define DR_REG_IO_MUX_BASE                      0x3ff49000
+#define DR_REG_RTCCNTL_BASE                     0x3f408000
+#define DR_REG_IO_MUX_BASE                      0x3f409000
 
 #endif /* _ELF_ESP32S2ULP_H */


### PR DESCRIPTION
As per ESP32-S2 [Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf) (TRM) v1.1, the base address for the peripheral registers on the ESP32-S2 is `0x3f408000` instead of `0x3ff48000` (as it was on the original ESP32). See Table 10 on page 48, and also also Figure 3-1 on page 110.

See also the [include file in the ESP-IDF](https://github.com/espressif/esp-idf/blob/v5.0.2/components/soc/esp32s2/include/soc/reg_base.h#L31), which also uses `0x3f408000` instead of `0x3ff48000`.